### PR TITLE
Fix cassandra-build command

### DIFF
--- a/DockerfileCassandra
+++ b/DockerfileCassandra
@@ -12,7 +12,8 @@ RUN apt-get update && \
    python-dev \
    dpatch \
    bash-completion \
-   quilt
+   quilt \
+   rsync
 
 
 RUN mkdir /cassandra

--- a/DockerfileCassandra
+++ b/DockerfileCassandra
@@ -13,8 +13,8 @@ RUN apt-get update && \
    dpatch \
    bash-completion \
    quilt \
-   rsync
-
+   rsync \
+   equivs
 
 RUN mkdir /cassandra
 

--- a/bin/build_cassandra.sh
+++ b/bin/build_cassandra.sh
@@ -11,14 +11,13 @@ rsync -av /cassandra/ /build/
 
 cd /build
 
-ant
-
 export JAVA8_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
 
+ant
 
 # Install build dependencies and build package
-echo "y" | sudo mk-build-deps --install
+echo "y" | mk-build-deps --install
 dpkg-buildpackage -uc -us
 
 

--- a/bin/tlp-cluster
+++ b/bin/tlp-cluster
@@ -311,7 +311,7 @@ EOF
             )
         fi
 
-        docker_c up build-cassandra
+        docker_c build build-cassandra && docker_c up build-cassandra
         ;;
 
 

--- a/manual/index.adoc
+++ b/manual/index.adoc
@@ -10,7 +10,7 @@ This is the manual for tlp-cluster, a provisioning tool for Apache Cassandra des
 There are some AWS resources tlp-cluster expects to exist:
 
 - A security group that allows inbound SSH traffic.
-- A key pair, private part of which should be present in your `~/.ssh` with `chmod 400` on it.
+- A key pair, private part of which should be present in your `~/.ssh` with `chmod 400` on it. The key needs to be named `id_rsa`, otherwise `pssh` won't see it.
 
 == Installation
 

--- a/manual/index.adoc
+++ b/manual/index.adoc
@@ -102,3 +102,44 @@ You can run arbitrary commands on all hosts:
 ----
 tlp-cluster cs ls
 ----
+
+
+== Build Cassandra
+
+Prepare a Cassandra package for installation on the machines:
+
+
+[source,bash]
+----
+tlp-cluster build-cassandra trunk trunk
+----
+
+This command will build a Debian package straight from the latest Cassandra sources. If all goes well, a brand new `.deb` file should appear in `~/.tlp-cluster/builds/trunk/deb/`
+
+
+== Install Casandra
+
+The following command will take a built Debian package and copy it to the local `provisioning` folder:
+
+[source,bash]
+----
+tlp-cluster use trunk
+----
+
+Now it's also a good time to edit Cassandra settings. In the `provisioning/cassandra` folder you'll find both `cassandra.yaml` and `cassandra-env.sh` files.
+
+When you're ready to actually install Cassandra, just run the following:
+
+[source,bash]
+----
+tlp-cluster install
+----
+
+Ultimately, you should get your Cassandra cluster up, which should allow you to run commands like:
+
+[source,bash]
+----
+tlp-cluster cs nodetool status
+----
+
+For connecting to the cluster with CQL, see the content of `seeds.txt` for contact points.

--- a/provisioning/install.sh
+++ b/provisioning/install.sh
@@ -41,6 +41,8 @@ echo "Done with shell scripts"
 
 echo "Installing all deb packages"
 
+apt-get update
+
 for d in $(ls *.deb)
 do
     apt-get install -y ./${d}


### PR DESCRIPTION
I ran into a few problems when trying to make a trunk-based cassandra build.

First, it turned out rsync was missing. Without rsync in the container, the cassandra build process fails to start:

```
+ docker-compose -f ./docker-compose.yml up --force-recreate build-cassandra
Recreating tlp-cluster_build-cassandra_1 ... done
Attaching to tlp-cluster_build-cassandra_1
build-cassandra_1  | /usr/bin/build_cassandra.sh: line 10: rsync: command not found
build-cassandra_1  | Buildfile: build.xml does not exist!
```

Second, java home paths were not set, and sudo command was not found:
```
build-cassandra_1  | _build_multi_java:
build-cassandra_1  |      [echo] Compiling for Java 8 (using ${env.JAVA8_HOME}/bin/javac) ...
build-cassandra_1  |     [javac] Compiling 1742 source files to /build/build/classes/main
build-cassandra_1  |
build-cassandra_1  | BUILD FAILED
build-cassandra_1  | /build/build.xml:864: The following error occurred while executing this line:
build-cassandra_1  | /build/build.xml:836: Error running ${env.JAVA8_HOME}/bin/javac compiler
...
build-cassandra_1  | Total time: 10 seconds
build-cassandra_1  | /usr/bin/build_cassandra.sh: line 21: sudo: command not found
```

When I removed the sudo, it turned out the mk-build-debs is missing some dependency:
```
build-cassandra_1  | BUILD SUCCESSFUL
build-cassandra_1  | Total time: 39 seconds
build-cassandra_1  | mk-build-deps: You must have equivs installed to use this program.
```

With all these added, `tlp-cluster bc trunk trunk` results in `~/.tlp-cluster/builds/trunk/deb/cassandra_4.0_all.deb` showing up.