### PR TITLE
Add missing dependencies for the build container

### DIFF
--- a/DockerfileCassandra
+++ b/DockerfileCassandra
@@ -12,7 +12,10 @@ RUN apt-get update && \
    python-dev \
    dpatch \
    bash-completion \
-   quilt
+   quilt \
+   rsync \
+   sudo \
+   equivs
 
 
 RUN mkdir /cassandra


### PR DESCRIPTION
Trying to run `tlp-cluster build ...` would fail without the added dependencies.