### PR TITLE
Added the ability to use custom AZ lists during init invocation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,8 @@ dependencies {
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.1'
 
     compile 'com.github.ajalt:mordant:1.2.1'
+
+    testCompile "io.mockk:mockk:1.9.3"
 }
 
 task docs(type:Exec) {

--- a/src/main/kotlin/com/thelastpickle/tlpcluster/commands/converters/AZConverter.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpcluster/commands/converters/AZConverter.kt
@@ -1,0 +1,27 @@
+package com.thelastpickle.tlpcluster.commands.converters
+
+import com.beust.jcommander.IStringConverter
+
+/**
+ * The AZConverter is meant to be crazy simple and if a person is guessing, they'll just guess right
+ * If somebody were to enter any of the following after --az, it should parse:
+ *
+ * abc
+ * a,b,c
+ * "a    b    , c"
+ *
+ * For now we don't care about regions - if a user enters this:
+ *
+ * us-west-2b
+ *
+ * It'll just fail.  We might follow up to fix this is we see it's an issue.
+ */
+class AZConverter : IStringConverter<List<String>> {
+    override fun convert(value: String?): List<String> {
+
+        if(value == null) return listOf()
+
+        return value.split("").filter { it.matches("[a-z]".toRegex()) }
+    }
+
+}

--- a/src/main/kotlin/com/thelastpickle/tlpcluster/terraform/Configuration.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpcluster/terraform/Configuration.kt
@@ -46,6 +46,8 @@ class Configuration(val ticket: String,
         mapper.enable(SerializationFeature.INDENT_OUTPUT)
     }
 
+    var azs = regionLookup.getAzs(region)
+
     fun setVariable(key: String, default: String?) : Configuration {
         config.variable[key] = Variable(default)
         return this
@@ -92,7 +94,7 @@ class Configuration(val ticket: String,
         setVariable("key_path", context.userConfig.sshKeyPath)
         setVariable("region", region)
 
-        val azs = regionLookup.getAzs(region)
+
 
         setVariable("zones", Variable(azs))
 

--- a/src/test/kotlin/com/thelastpickle/tlpcluster/commands/InitTest.kt
+++ b/src/test/kotlin/com/thelastpickle/tlpcluster/commands/InitTest.kt
@@ -1,0 +1,39 @@
+package com.thelastpickle.tlpcluster.commands
+
+import com.thelastpickle.tlpcluster.Context
+import com.thelastpickle.tlpcluster.terraform.Configuration
+import io.mockk.every
+import io.mockk.mockkObject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class InitTest {
+    val testContext = Context.testContext()
+    val testConfiguration = Configuration("ticket", "client", "purpose", "us-west-2", testContext)
+
+    @Test
+    fun testExpand() {
+        val result = Init.expand("us-west-1", listOf("a", "b"))
+        assertThat(result).isEqualTo(listOf("us-west-1a", "us-west-1b"))
+    }
+
+
+    @Test
+    fun testAZsGetSetCorrectly() {
+        val init = Init(testContext).apply {
+            tags = mutableListOf("client", "ticket", "purpose")
+            azs = listOf("a", "b", "c")
+        }
+
+        mockkObject(init)
+
+        every { init.writeTerraformConfig(any()) } returns Result.success("")
+        every { init.initializeDirectory(any(), any(), any()) } returns testConfiguration
+
+
+        init.execute()
+
+
+    }
+
+}

--- a/src/test/kotlin/com/thelastpickle/tlpcluster/commands/converters/AZConverterTest.kt
+++ b/src/test/kotlin/com/thelastpickle/tlpcluster/commands/converters/AZConverterTest.kt
@@ -1,0 +1,33 @@
+package com.thelastpickle.tlpcluster.commands.converters
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+internal class AZConverterTest {
+
+    val converter = AZConverter()
+
+    val abc = listOf("a", "b", "c")
+
+    @Test
+    fun testNoBreak() {
+        assertThat(converter.convert("abc")).isEqualTo(abc)
+    }
+
+    @Test
+    fun testEmpty() {
+        assertThat(converter.convert("")).isEmpty()
+    }
+
+    @Test
+    fun testCommas() {
+        assertThat(converter.convert("a,b,c")).isEqualTo(abc)
+    }
+
+    @Test
+    fun testStupidMix() {
+        assertThat(converter.convert("a    b    , c")).isEqualTo(abc)
+    }
+}


### PR DESCRIPTION
Added the AZ converter and --azs flag in the Init class.
Added the mock library to enable us to do better testing on the init subcommand.
Reworked code to separate the directory initialization and terraform
call to make mocking easier.

Closes #87