### PR TITLE
Add Reaper to the clusters

### DIFF
--- a/src/main/kotlin/com/thelastpickle/tlpcluster/commands/Init.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpcluster/commands/Init.kt
@@ -54,7 +54,7 @@ class Init(val context: Context) : ICommand {
         check(ticket.isNotBlank())
         check(purpose.isNotBlank())
 
-        val allowedTypes = listOf("m1", "m3", "t1", "c1", "c3", "cc2", "cr1", "m2", "r3", "d2", "hs1", "i2")
+        val allowedTypes = listOf("m1", "m3", "t1", "c1", "c3", "cc2", "cr1", "m2", "r3", "d2", "hs1", "i2", "c5", "m5")
 
         var found = false
         for(x in allowedTypes) {

--- a/src/main/kotlin/com/thelastpickle/tlpcluster/containers/Pssh.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpcluster/containers/Pssh.kt
@@ -14,6 +14,7 @@ class Pssh(val context: Context, val sshKey: String) {
     private val dockerImageTag = "thelastpickle/tlp-cluster_pssh"
 
     private val provisionCommand = "cd provisioning; chmod +x install.sh; sudo ./install.sh"
+    private val postStartCommand = "cd provisioning; chmod +x post_start.sh; sudo ./post_start.sh"
 
     val log = logger()
     init {
@@ -25,7 +26,6 @@ class Pssh(val context: Context, val sshKey: String) {
     fun createGrafanaDashboard() : Result<String> {
         return execute("create_dashboard.sh", "", ServerType.Monitoring)
     }
-
 
     fun copyProvisioningResources(nodeType: ServerType) : Result<String> {
         return execute("copy_provisioning_resources.sh", "", nodeType)
@@ -45,7 +45,7 @@ class Pssh(val context: Context, val sshKey: String) {
 
     private fun serviceCommand(nodeType: ServerType, serviceName: String, command: String) : Result<String> {
         return execute("parallel_ssh.sh",
-                "sudo service $serviceName $command && sleep 5 && sudo service $serviceName status",
+                "sudo service $serviceName $command && sleep 5 && sudo service $serviceName status && $postStartCommand ${nodeType.serverType}",
                 nodeType)
     }
 

--- a/src/main/kotlin/com/thelastpickle/tlpcluster/terraform/Configuration.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpcluster/terraform/Configuration.kt
@@ -109,6 +109,7 @@ class Configuration(val ticket: String,
             .withInboundSelfRule(0, 65535, "tcp", "Intra node")
             .withInboundRule(9090, 9090, "tcp", externalCidr, "Prometheus GUI")
             .withInboundRule(3000, 3000, "tcp", externalCidr, "Grafana GUI")
+            .withInboundRule(8080, 8080, "tcp", externalCidr, "Reaper GUI")
             .build()
 
         setSecurityGroupResource(instanceSg)

--- a/src/main/resources/com/thelastpickle/tlpcluster/commands/origin/provisioning/cassandra/80_install_reaper.sh
+++ b/src/main/resources/com/thelastpickle/tlpcluster/commands/origin/provisioning/cassandra/80_install_reaper.sh
@@ -1,0 +1,11 @@
+if ls reaper_*.deb 1> /dev/null 2>&1; then
+    echo "Reaper was already installed using the provided deb package"
+else
+    echo "Installing Reaper latest beta from the repo"
+    echo "deb https://dl.bintray.com/thelastpickle/reaper-deb-beta wheezy main" | sudo tee -a /etc/apt/sources.list
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 2895100917357435
+    sudo apt-get update
+    sudo apt-get install reaper
+fi
+cp /etc/cassandra-reaper/configs/cassandra-reaper-cassandra-sidecar.yaml /etc/cassandra-reaper/cassandra-reaper.yaml
+sudo sed -i "s/contactPoints: \[\"127.0.0.1\"\]/contactPoints: [\"$(hostname)\"]/" /etc/cassandra-reaper/cassandra-reaper.yaml

--- a/src/main/resources/com/thelastpickle/tlpcluster/commands/origin/provisioning/cassandra/post_start/10_start_reaper.sh
+++ b/src/main/resources/com/thelastpickle/tlpcluster/commands/origin/provisioning/cassandra/post_start/10_start_reaper.sh
@@ -1,0 +1,2 @@
+cqlsh $(hostname) -e "CREATE KEYSPACE IF NOT EXISTS reaper_db with replication = {'class':'SimpleStrategy', 'replication_factor':3}"
+service cassandra-reaper start

--- a/src/main/resources/com/thelastpickle/tlpcluster/commands/origin/provisioning/post_start.sh
+++ b/src/main/resources/com/thelastpickle/tlpcluster/commands/origin/provisioning/post_start.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# anything that should be executed after Cassandra was started
+
+cassandra_running() {
+  nc -zv $(hostname) 9042 > /dev/null 2>&1
+}
+
+if [[ "$1" == "" ]]; then
+echo "Pass a provisioning argument please"
+exit 1
+fi
+
+if [[ "$1" == "cassandra" ]]; then
+    # Wait for Cassandra to be fully started
+    for i in $(seq 90); do
+      if cassandra_running; then
+            break
+      fi
+      echo "Cassandra is not running yet..."
+      sleep 1s
+    done
+
+    echo "Running all shell scripts"
+    # subshell
+    (
+    cd "$1/post_start"
+    for f in $(ls [0-9]*.sh)
+    do
+        bash ${f}
+    done
+
+    echo "Done with shell scripts"
+    )
+fi
+


### PR DESCRIPTION
PR for adding Reaper to tlp-cluster nodes.
It adds a `post_start.sh` script which runs all scripts in `provisioning/cassandra/post_start` and is executed after Cassandra has started up using `tlp-cluster start`.

Reaper gets installed from the debian repo in Bintray unless a deb package is provided in the `provisioning` directory.