### PR TITLE
Replaced the ubuntu pssh container with an alpine based image.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 
 buildscript {
-    ext.kotlin_version = "1.3.41"
+    ext.kotlin_version = "1.3.50"
     ext.jcommander_version = "1.72"
+    ext.docker_compose_version = "0.9.4"
     
     repositories {
         mavenCentral()
@@ -11,8 +12,11 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
         classpath "com.netflix.nebula:gradle-ospackage-plugin:6.2.1"
+        classpath "com.avast.gradle:gradle-docker-compose-plugin:$docker_compose_version"
     }
 }
+
+
 
 // Apply the java plugin to add support for Java
 apply plugin: 'idea'
@@ -34,9 +38,11 @@ application {
 }
 
 // In this section you declare where to find the dependencies of your project
-repositories {
-    mavenCentral()
-    jcenter()
+allprojects {
+    repositories {
+        mavenCentral()
+        jcenter()
+    }
 }
 
 
@@ -83,7 +89,10 @@ dependencies {
     compile 'com.github.ajalt:mordant:1.2.1'
 
     testCompile "io.mockk:mockk:1.9.3"
+
 }
+
+build.dependsOn(":docker-pssh:buildDocker")
 
 task docs(type:Exec) {
     environment "TLP_CLUSTER_VERSION", version

--- a/docker-pssh/build.gradle
+++ b/docker-pssh/build.gradle
@@ -1,0 +1,66 @@
+plugins {
+    id 'com.bmuschko.docker-remote-api'
+    id 'docker-compose'
+}
+
+import com.bmuschko.gradle.docker.tasks.image.*
+import com.bmuschko.gradle.docker.tasks.container.*
+
+
+
+ext {
+    container = "thelastpickle/pssh"
+    dockerTag = 1.0
+}
+
+task buildDocker(type: DockerBuildImage) {
+    tags = ["$container:latest".toString(), "$container:$dockerTag".toString()]
+}
+
+task push(type: DockerPushImage) {
+    dependsOn buildDocker
+    imageName = "thelastpickle/pssh"
+}
+
+docker {
+    registryCredentials {
+        url = 'https://index.docker.io/v1/'
+        username = System.getenv("DOCKER_USERNAME")
+        password = System.getenv("DOCKER_PASSWORD")
+        email = System.getenv("DOCKER_EMAIL")
+    }
+}
+
+dockerCompose {
+
+}
+
+// need to add testing with the below:
+// https://bmuschko.github.io/gradle-docker-plugin/#linking_with_other_containers
+
+task createContainer(type: DockerCreateContainer) {
+    dependsOn(buildDocker)
+    targetImageId {
+        buildDocker.getImageId()
+    }
+    cmd = ["/usr/local/bin/parallel_ssh.sh"]
+}
+
+task startContainer(type: DockerStartContainer) {
+    dependsOn createContainer
+    targetContainerId { createContainer.getContainerId() }
+}
+
+task startAndWaitOnContainer(type: DockerWaitContainer) {
+    dependsOn startContainer
+    targetContainerId { createContainer.getContainerId() }
+}
+
+task inspectResult(type: DockerInspectExecContainer) {
+    dependsOn startAndWaitOnContainer
+
+
+}
+
+
+dockerCompose.isRequiredBy(startAndWaitOnContainer)

--- a/docker-pssh/docker-compose.yml
+++ b/docker-pssh/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.7"
+
+services:
+  ubuntu:
+    image: "rastasheep/ubuntu-sshd:18.04"
+    expose:
+      - 22

--- a/docker-pssh/docker/Dockerfile
+++ b/docker-pssh/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.10.2
+
+COPY parallel_ssh.sh /usr/local/bin/
+COPY copy_provisioning_resources.sh /usr/local/bin/
+
+RUN apk --no-cache add pssh rsync curl jq openssh-client && \
+ mkdir /tlp && \
+ mkdir /root/.ssh && \
+ chmod +x /usr/local/bin/*.sh
+
+WORKDIR /local

--- a/docker-pssh/docker/copy_provisioning_resources.sh
+++ b/docker-pssh/docker/copy_provisioning_resources.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 
 set -ex
-
 eval $(ssh-agent)
 ssh-add /root/.ssh/aws-private-key
 
 cd /local
 
-parallel-rsync \
+echo "Starting parallel rsync"
+
+prsync \
     -avrz  \
     -H "${PSSH_HOSTNAMES}" \
     -l ubuntu \

--- a/docker-pssh/docker/parallel_ssh.sh
+++ b/docker-pssh/docker/parallel_ssh.sh
@@ -7,7 +7,7 @@ ssh-add /root/.ssh/aws-private-key
 
 cd /local
 
-parallel-ssh \
+pssh \
     -ivl ubuntu \
     -O StrictHostKeyChecking=no \
     -O UserKnownHostsFile=/dev/null \

--- a/docs/index.html
+++ b/docs/index.html
@@ -511,7 +511,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p>The easiest way to get started is to use your favorite package manager.</p>
 </div>
 <div class="paragraph">
-<p>The current version is 0.2.</p>
+<p>The current version is .</p>
 </div>
 <div class="sect3">
 <h4 id="_deb_packages">Deb Packages</h4>
@@ -555,8 +555,8 @@ enabled=1</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code>$ curl -L -O "https://dl.bintray.com/thelastpickle/tlp-tools-tarball/tlp-cluster-0.2.tar
-$ tar -xzf tlp-cluster-0.2.tar</code></pre>
+<pre class="highlight"><code>$ curl -L -O "https://dl.bintray.com/thelastpickle/tlp-tools-tarball/tlp-cluster-.tar
+$ tar -xzf tlp-cluster-.tar</code></pre>
 </div>
 </div>
 <div class="paragraph">

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,3 +16,4 @@ include 'services:webservice'
 */
 
 rootProject.name = 'tlp-cluster'
+include "docker-pssh"

--- a/src/main/kotlin/com/thelastpickle/tlpcluster/Docker.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpcluster/Docker.kt
@@ -41,7 +41,10 @@ class Docker(val context: Context) {
         return this
     }
 
-
+    fun exists(name: String, tag: String) : Boolean {
+        val result = context.docker.listImagesCmd().withImageNameFilter("$name:$tag").exec()
+        return result.size > 0
+    }
     /**
      * Tag is required here, otherwise we pull every tag
      * and that isn't fun

--- a/src/main/resources/com/thelastpickle/tlpcluster/containers/DockerfileSSH
+++ b/src/main/resources/com/thelastpickle/tlpcluster/containers/DockerfileSSH
@@ -1,8 +1,0 @@
-FROM ubuntu:bionic
-
-
-RUN apt-get update && apt-get install -y pssh rsync curl jq
-
-RUN mkdir /tlp
-RUN mkdir /root/.ssh
-


### PR DESCRIPTION
* pssh is now a docker subproject located at docker-pssh.
* The base image is switched from ubuntu to alpine linux
* The beginnings of a build test system are included, but non functional.

You'll need to build the pssh docker container locally to test it.  Do the following before you start your review:

```
./gradlew clean :docker-pssh:buildDocker shadowJar
```

I'll push it up when merging into master so it'll be available for folks when they run the container.