### PR TITLE
Use main Grafonnet repo (instead of TLP fork)

### DIFF
--- a/docker-grafonnet/build.gradle
+++ b/docker-grafonnet/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.bmuschko.docker-remote-api'
 }
 
-version "2.0"
+version "3.0"
 
 import com.bmuschko.gradle.docker.tasks.image.*
 
@@ -28,4 +28,3 @@ task push(type: DockerPushImage) {
     dependsOn buildDocker
     imageName = container
 }
-

--- a/docker-grafonnet/docker/Dockerfile
+++ b/docker-grafonnet/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM  sparkprime/jsonnet
 
-RUN apk update && apk add git && git clone https://github.com/thelastpickle/grafonnet-lib.git && \
-    cd grafonnet-lib && git checkout 80f8b8746ebbf63117e6fc8e75f07fc3900be805
+RUN apk update && apk add git && git clone https://github.com/grafana/grafonnet-lib.git && \
+    cd grafonnet-lib && git checkout 47db72da03fc4a7a0658a87791e13c3315a3a252
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh


### PR DESCRIPTION
@rustyrazorblade could you please ensure I did not forget anything. I don't think this change impacts tlp-cluster repo more than this.