### PR TITLE
Added small single stats to overview dashboard.

### DIFF
--- a/dashboards/dashboards/caches.jsonnet
+++ b/dashboards/dashboards/caches.jsonnet
@@ -1,0 +1,119 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local row = grafana.row;
+local graphPanel = grafana.graphPanel;
+local tablePanel = grafana.tablePanel;
+local singleStatPanel = grafana.singlestat;
+local textPanel = grafana.text;
+local prometheus = grafana.prometheus;
+local template = grafana.template;
+
+
+// used in the single stat panels where higher is better - cache hit rates for example
+local reversedColors =[
+ '#d44a3a',
+ 'rgba(237, 129, 40, 0.89)',
+ '#299c46',
+];
+
+local smallGrid = {
+  "w": 4,
+  "h": 4
+};
+
+local singleStatCachePanel(name, scope) =
+    singleStatPanel.new(name,
+              span=2,
+              colors=reversedColors,
+              datasource='$PROMETHEUS_DS',
+              format='percent',
+              decimals=0,
+              gaugeShow=true,
+              timeFrom="",
+              valueMaps=[
+                  {
+                    "op": "=",
+                    "text": "0",
+                    "value": "null"
+                  }
+                ],
+              thresholds="80,90",
+
+            )
+            .addTarget(
+              prometheus.target(
+                  'avg(irate(org_apache_cassandra_metrics_cache_count{scope="%(scope)s", name="Hits"}[1m]) / on (instance) irate(org_apache_cassandra_metrics_cache_count{scope="%(scope)s", name="Requests"}[1m])) * 100' % {scope:scope}
+              )
+            );
+
+local cacheGraphPanel(name, scope) =
+    graphPanel.new(name,
+              datasource='$PROMETHEUS_DS',
+              format='percentunit',
+              decimals=1,
+            )
+            .addTarget(
+              prometheus.target(
+                  'org_apache_cassandra_metrics_cache_oneminuterate{scope="%(scope)s", name="Hits"} / on (instance) org_apache_cassandra_metrics_cache_oneminuterate{scope="%(scope)s", name="Requests"} ' % {scope:scope},
+                  legendFormat="{{instance}}"
+              )
+            );
+
+
+dashboard.new(
+  'Caches',
+  schemaVersion=14,
+  refresh='1m',
+  time_from='now-15m',
+  editable=true,
+  tags=['Cassandra', 'Resources', 'Cache'],
+)
+.addTemplate(
+  grafana.template.datasource(
+    'PROMETHEUS_DS',
+    'prometheus',
+    'Prometheus',
+    hide='label',
+  )
+)
+.addTemplate(
+  template.new(
+    'node',
+    '$PROMETHEUS_DS',
+    'label_values(node_cpu_seconds_total{cpu="0", mode="user", environment="$environment", cluster="$cluster", datacenter=~"$datacenter", rack=~"$rack"}, node)',
+    label='Node',
+    refresh='time',
+    current='all',
+    includeAll=true,
+    multi=true,
+  )
+)
+
+.addRow(
+  row.new("Quick Stats")
+   .addPanel(singleStatCachePanel("Key Cache Hit Rate", "KeyCache"), smallGrid)
+   .addPanel(singleStatCachePanel("Counter Cache Hit Rate", "CounterCache"), smallGrid)
+   .addPanel(singleStatCachePanel("Row Cache Hit Rate", "RowCache"), smallGrid)
+   .addPanel(singleStatCachePanel("Chunk Cache Hit Rate", "ChunkCache"), smallGrid)
+)
+.addRow(
+    row.new("Key Cache")
+    .addPanel(cacheGraphPanel("Key Cache", "KeyCache"))
+
+)
+.addRow(
+    row.new("Counter Cache")
+    .addPanel(cacheGraphPanel("Counter Cache", "CounterCache"))
+)
+.addRow(
+    row.new("Row Cache")
+    .addPanel(cacheGraphPanel("Row Cache", "RowCache"))
+
+)
+.addRow(
+    row.new("Chunk Cache")
+    .addPanel(cacheGraphPanel("Chunk Cache", "ChunkCache"))
+)
+
+
+

--- a/docker-grafonnet/build.gradle
+++ b/docker-grafonnet/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.bmuschko.docker-remote-api'
 }
 
-version "3.0"
+version "4.0"
 
 import com.bmuschko.gradle.docker.tasks.image.*
 

--- a/docker-grafonnet/docker/Dockerfile
+++ b/docker-grafonnet/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM  sparkprime/jsonnet
 
 RUN apk update && apk add git && git clone https://github.com/grafana/grafonnet-lib.git && \
-    cd grafonnet-lib && git checkout 47db72da03fc4a7a0658a87791e13c3315a3a252
+    cd grafonnet-lib && git checkout f3ee1d810858cf556d25f045b53cb0f1fd10b94e
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh


### PR DESCRIPTION
Improved layout and presentation of row and key cache.
Added CPU stat
Added avg CPU and requests per second
added disk and network throughput.  added blocked tasks
Adding a new caches dashboard to the project.  Moved the row and key cache out to caches.
added key cache hit rate graph, per node
Fixed key cache gauge
added single stat panels for caches
new rows and panels for 4 caches

Closes #154
Closes #153

https://circleci.com/gh/thelastpickle/tlp-cluster/348