### PR TITLE
Fix interactive prompt issue with libssl1.1 installation

### DIFF
--- a/src/main/resources/com/thelastpickle/tlpcluster/commands/origin/provisioning/install.sh
+++ b/src/main/resources/com/thelastpickle/tlpcluster/commands/origin/provisioning/install.sh
@@ -12,7 +12,7 @@ exit 1
 fi
 
 echo "installing common utilities"
-sudo apt install -y sysstat dstat iftop ifstat htop bpfcc-tools
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y sysstat dstat iftop ifstat htop bpfcc-tools
 
 
 


### PR DESCRIPTION
Fixes `tlp-cluster install` being blocked by interactive prompts.