### PR TITLE
Fixes #158 - Adds singlestats for nodes down

### DIFF
--- a/dashboards/dashboards/overview.jsonnet
+++ b/dashboards/dashboards/overview.jsonnet
@@ -99,6 +99,179 @@ dashboard.new(
   )
 )
 .addRow(
+  row.new(title='Nodes Status',)
+  .addPanel(
+    singleStatPanel.new(
+      'Nodes Count',
+      description='Nodes up and down in the cluster',
+      format='short',
+      datasource='$PROMETHEUS_DS',
+      transparent=true,
+      decimals=0,
+      prefix='Total:',
+      postfix=' Nodes',
+      postfixFontSize='80%',
+      valueFontSize='80%',
+      span=4
+    )
+    .addTarget(
+      prometheus.target(
+        'count by (environment, cluster) (max by (environment, cluster, datacenter, rack, node) (up{job="cassandra", environment="$environment", cluster="$cluster", datacenter=~"$datacenter", rack=~"$rack", node=~"$node"}))',
+        legendFormat='Total Number Of Nodes',
+      )
+    )
+  )
+  .addPanel(
+    graphPanel.new(
+      'Nodes Status History',
+      description='Nodes up and down in the cluster per protocol/activity',
+      format='short',
+      datasource='$PROMETHEUS_DS',
+      transparent=true,
+      decimals=0,
+      fill=0,
+      legend_show=true,
+      legend_values=true,
+      legend_current=true,
+      legend_alignAsTable=true,
+      legend_sort='current',
+      legend_sortDesc=false,
+      shared_tooltip=false,
+      min=0,
+      span=8
+    )
+    .addTarget(
+      prometheus.target(
+        'count by (environment, cluster) (max by (environment, cluster, datacenter, rack, node) (up{job="cassandra", environment="$environment", cluster="$cluster", datacenter=~"$datacenter", rack=~"$rack", node=~"$node"}))',
+        legendFormat='Total Number Of Nodes',
+      )
+    )
+    .addTarget(
+      prometheus.target(
+        'sum by (environment, cluster) (max by (environment, cluster, datacenter, rack, node) (changes(org_apache_cassandra_metrics_threadpools_value{scope="Native-Transport-Requests", environment="$environment", cluster="$cluster", datacenter=~"$datacenter", rack=~"$rack", node=~"$node"}[1m])) > bool 0)',
+        legendFormat='Nodes Coordinating Requests (Native protocol)',
+      )
+    )
+    .addTarget(
+      prometheus.target(
+        'sum by (environment, cluster) (max by (environment, cluster, datacenter, rack, node) (changes(org_apache_cassandra_metrics_threadpools_value{scope="GossipStage", environment="$environment", cluster="$cluster", datacenter=~"$datacenter", rack=~"$rack", node=~"$node"}[1m])) > bool 0)',
+        legendFormat='Nodes With Internal Activity (Gossip protocol)',
+      )
+    )
+    .addTarget(
+      prometheus.target(
+        'sum by (environment, cluster) (max by (environment, cluster, datacenter, rack, node) (up{job="cassandra", environment="$environment", cluster="$cluster", datacenter=~"$datacenter", rack=~"$rack", node=~"$node"}))',
+        legendFormat='Node Reporting Metrics (Monitoring)',
+      )
+    )
+  )
+  .addPanel(
+    singleStatPanel.new(
+      'Native Up?',
+      datasource='$PROMETHEUS_DS',
+      description='Nodes up and down in the cluster from a client perspective (ie. Native requests are received)',
+      format='percent',
+      transparent=true,
+      decimals=0,
+      valueFontSize='80%',
+      valueName="current",
+      thresholds='80,95,100',
+      timeFrom='1m',
+      colors=[
+      "#F2495C",
+      "#FF9830",
+      "#73BF69"
+      ],
+      gaugeShow=true,
+      gaugeMinValue=0,
+      gaugeMaxValue=100,
+      gaugeThresholdLabels=false,
+      gaugeThresholdMarkers=false,
+      sparklineFull=false,
+      sparklineShow=false,
+      span=4
+    )
+    .addTarget(
+      prometheus.target(
+        '(sum by (environment, cluster) (max by (environment, cluster, datacenter, rack, node) (changes(org_apache_cassandra_metrics_threadpools_value{scope="Native-Transport-Requests", environment="$environment", cluster="$cluster", datacenter=~"$datacenter", rack=~"$rack", node=~"$node"}[1m])) > bool 0))
+        * 100
+        / (count by (environment, cluster) (max by (environment, cluster, datacenter, rack, node) (up{job="cassandra", environment="$environment", cluster="$cluster", datacenter=~"$datacenter", rack=~"$rack", node=~"$node"})))',
+        legendFormat='Nodes Coordinating Requests',
+      )
+    )
+  )
+  .addPanel(
+    singleStatPanel.new(
+      'Gossip Up?',
+      datasource='$PROMETHEUS_DS',
+      description='Nodes up and down in the cluster from an internal perspective (ie. Gossip messages are received)',
+      format='percent',
+      transparent=true,
+      decimals=0,
+      valueFontSize='80%',
+      valueName="current",
+      thresholds='80,95,100',
+      timeFrom='1m',
+      colors=[
+      "#F2495C",
+      "#FF9830",
+      "#73BF69"
+      ],
+      gaugeShow=true,
+      gaugeMinValue=0,
+      gaugeMaxValue=100,
+      gaugeThresholdLabels=false,
+      gaugeThresholdMarkers=false,
+      sparklineFull=false,
+      sparklineShow=false,
+      span=4
+    )
+    .addTarget(
+      prometheus.target(
+        '(sum by (environment, cluster) (max by (environment, cluster, datacenter, rack, node) (changes(org_apache_cassandra_metrics_threadpools_value{scope="GossipStage", environment="$environment", cluster="$cluster", datacenter=~"$datacenter", rack=~"$rack", node=~"$node"}[1m])) > bool 0))
+        * 100
+        / (count by (environment, cluster) (max by (environment, cluster, datacenter, rack, node) (up{job="cassandra", environment="$environment", cluster="$cluster", datacenter=~"$datacenter", rack=~"$rack", node=~"$node"})))',
+        legendFormat='Nodes With Internal Activity (Gossip protocol)',
+      )
+    )
+  )
+  .addPanel(
+    singleStatPanel.new(
+      'Reporting Up?',
+      datasource='$PROMETHEUS_DS',
+      description='Nodes up and down in the cluster from a metrics reporting perspective - not critical',
+      format='percent',
+      transparent=true,
+      decimals=0,
+      valueFontSize='80%',
+      valueName="current",
+      thresholds='80,95,100',
+      timeFrom='1m',
+      colors=[
+      "#F2495C",
+      "#FF9830",
+      "#73BF69"
+      ],
+      gaugeShow=true,
+      gaugeMinValue=0,
+      gaugeMaxValue=100,
+      gaugeThresholdLabels=false,
+      gaugeThresholdMarkers=false,
+      sparklineFull=false,
+      sparklineShow=false,
+      span=4
+    )
+    .addTarget(
+      prometheus.target(
+        '(sum by (environment, cluster) (max by (environment, cluster, datacenter, rack, node) (up{job="cassandra", environment="$environment", cluster="$cluster", datacenter=~"$datacenter", rack=~"$rack", node=~"$node"})))
+        * 100
+        / (count by (environment, cluster) (max by (environment, cluster, datacenter, rack, node) (up{job="cassandra", environment="$environment", cluster="$cluster", datacenter=~"$datacenter", rack=~"$rack", node=~"$node"})))',
+        legendFormat='Node Reporting Metrics (Monitoring)',
+      )
+    )
+  )
+)
+.addRow(
   row.new(title='Quick Stats')
   .addPanel(
     singleStatPanel.new(

--- a/dashboards/docker-compose.yml
+++ b/dashboards/docker-compose.yml
@@ -69,8 +69,8 @@ services:
     networks:
       - tlp_cluster_net
     environment:
-      # Attempts to get a nice nodes up/total panel...
-      - "GF_PANELS_DISABLE_SANITIZE_HTML=true"
+      - "GF_INSTALL_PLUGINS=grafana-polystat-panel"
+
 
   cassandra:
     image: cassandra:3.11.4


### PR DESCRIPTION
WIP:

v1: Single Stats panels. As we cannot define a dynamic threshold for formatting single stats, I work around showing a percentage of the nodes up/dow + a singlestat with the real number of nodes and a graphPanel with the history.

Maybe an image will help here:

<img width="1581" alt="Up and down nodes" src="https://user-images.githubusercontent.com/1073404/72427613-681e8080-378c-11ea-9926-e72effcaa799.png">

I think that's an improvement on what we currently have.
Yet I'm not satisfied.

v2: I'm considering to search a plugin to have a nicer view of nodes up and down. That would make user life easier and that would look nicer as well 🙂. I'm considering https://grafana.com/grafana/plugins/grafana-polystat-panel but I did not have the time to test it (before I add it to grafonnet lib and all that stuff if we like it...)