### PR TITLE
Allow 4.0 alphas to be pulled from the debian repo

### DIFF
--- a/src/main/kotlin/com/thelastpickle/tlpcluster/commands/UseCassandra.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpcluster/commands/UseCassandra.kt
@@ -47,7 +47,7 @@ class UseCassandra(val context: Context) : ICommand {
         }
 
         // if we're been passed a version, use the debs we get from apache
-        val versionRegex = """\d+\.\d+\.\d+""".toRegex()
+        val versionRegex = """\d+\.\d+[\.~]\w+""".toRegex()
 
 
         if(versionRegex.matches(name)) {


### PR DESCRIPTION
4.0 alphas (and all versions coming before stable) look like: 4.0~alpha1
Assuming that everything starting with 4.0 is an actual release so that tlp-cluster pulls the deb package from Bintray instead of trying to build Cassandra.