### PR TITLE
Download Cassandra debs from Apache mirror, not Bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ apply plugin: "nebula.ospackage"
 apply plugin: 'nebula.ospackage-application'
 
 group 'com.thelastpickle'
-version '0.8-SNAPSHOT'
+version '0.8'
 sourceCompatibility = 1.8
 
 ext {

--- a/src/main/kotlin/com/thelastpickle/tlpcluster/containers/CassandraUnpack.kt
+++ b/src/main/kotlin/com/thelastpickle/tlpcluster/containers/CassandraUnpack.kt
@@ -64,6 +64,6 @@ class CassandraUnpack(val context: Context,
         )
     }
 
-    fun getURL() = "http://dl.bintray.com/apache/cassandra/pool/main/c/cassandra/" + getFileName()
+    fun getURL() = "https://archive.apache.org/dist/cassandra/3.11.7/debian/" + getFileName()
     fun getFileName() = "cassandra_${version}_all.deb"
 }

--- a/src/test/kotlin/com/thelastpickle/tlpcluster/containers/CassandraUnpackTest.kt
+++ b/src/test/kotlin/com/thelastpickle/tlpcluster/containers/CassandraUnpackTest.kt
@@ -47,7 +47,7 @@ internal class CassandraUnpackTest {
 
     @Test
     fun getURL() {
-        val expected = "http://dl.bintray.com/apache/cassandra/pool/main/c/cassandra/cassandra_2.1.14_all.deb"
+        val expected = "https://archive.apache.org/dist/cassandra/3.11.7/debian/cassandra_2.1.14_all.deb"
         assertThat(unpacker.getURL()).isEqualTo(expected)
     }
 


### PR DESCRIPTION
Also made an issue to handle all the other bintray mentions: https://github.com/thelastpickle/tlp-cluster/issues/185